### PR TITLE
Replace log with logrus

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 

--- a/consul/data_source_consul_service_health.go
+++ b/consul/data_source_consul_service_health.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/consul/key_client.go
+++ b/consul/key_client.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/consul/resource_consul_keys_migrate.go
+++ b/consul/resource_consul_keys_migrate.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -6,7 +6,7 @@ package consul
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 


### PR DESCRIPTION
Namespace(repository='github.com/sourcegraph-ce/terraform-provider-consul', batch_change_name='log-provider-go-with-python-script', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script)