### PR TITLE
Replace log with logrus

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 

--- a/consul/data_source_consul_service_health.go
+++ b/consul/data_source_consul_service_health.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/consul/key_client.go
+++ b/consul/key_client.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/consul/resource_consul_keys_migrate.go
+++ b/consul/resource_consul_keys_migrate.go
@@ -5,7 +5,7 @@ package consul
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -6,7 +6,7 @@ package consul
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-consul', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
templates
.release
scripts
consul
.github
docs
assets
.git
data-sources
resources
kv
consul_peering
consul_peerings
consul_peering
consul_peering_token
data-sources
resources
guides
test-fixtures
docker
capath
workflows
data-sources
resources
guides
objects
info
branches
logs
refs
hooks
97
1b
08
8d
20
9f
24
6e
18
b6
78
66
fe
01
e4
d0
72
dc
12
b7
ee
11
c8
22
53
7a
07
81
75
8e
d6
96
e3
29
f2
ac
ec
69
a9
a3
6c
ea
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
a4
21
d2
82
9b
a0
fb
b4
cb
c1
74
61
d1
de
e9
pack
ef
8b
e8
b3
ce
79
3a
b5
f1
ae
e0
be
info
80
e5
ed
56
7d
2b
fc
ad
09
50
98
f0
70
7e
bc
0c
a8
5e
16
b1
40
67
ab
3d
e1
b9
6b
37
d3
33
2f
8f
d9
39
36
55
63
c4
92
68
f9
04
38
2c
8a
64
7b
48
cd
91
14
5d
bb
cc
58
45
f4
a1
25
6f
62
df
4d
0a
13
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)